### PR TITLE
Fix#25 airbnbratings

### DIFF
--- a/example/src/views/tabs.tsx
+++ b/example/src/views/tabs.tsx
@@ -15,7 +15,7 @@ export default () => {
           height: 3,
         }}
         scrollable
-        activeIndex={activeTabIndex}
+        value={activeTabIndex}
         onChange={setActiveTabIndex}
       >
         <TabBar.Item

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -44,11 +44,11 @@
   },
   "homepage": "https://thevikalpui.netlify.app/",
   "dependencies": {
+    "@rn-vui/ratings": "^0.4.1",
     "@types/react-native-vector-icons": "^6.4.10",
     "color": "^3.2.1",
     "deepmerge": "^4.2.2",
     "hoist-non-react-statics": "^3.3.2",
-    "react-native-ratings": "^8.1.0",
     "react-native-size-matters": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/base/src/AirbnbRating/AirbnbRating.tsx
+++ b/packages/base/src/AirbnbRating/AirbnbRating.tsx
@@ -5,7 +5,7 @@ import {
 } from '@rn-vui/ratings';
 import { RneFunctionComponent } from '../helpers';
 
-export interface TapRatingProps extends RatingProps { }
+export interface TapRatingProps extends RatingProps {}
 
 /** Ratings are used to collect measurable feedback from users.
  * Use Rating over an Input where imagery can increase user interaction.

--- a/packages/base/src/AirbnbRating/AirbnbRating.tsx
+++ b/packages/base/src/AirbnbRating/AirbnbRating.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import {
   AirbnbRating as TapRating,
   TapRatingProps as RatingProps,
-} from 'react-native-ratings';
+} from '@rn-vui/ratings';
 import { RneFunctionComponent } from '../helpers';
 
-export interface TapRatingProps extends RatingProps {}
+export interface TapRatingProps extends RatingProps { }
 
 /** Ratings are used to collect measurable feedback from users.
  * Use Rating over an Input where imagery can increase user interaction.
- * This component is imported from [react-native-ratings](https://github.com/Monte9/react-native-ratings).
+ * This component is imported from [@rn-vui/ratings](https://github.com/deepktp/react-native-vikalp-ratings).
  * There are two types of rating - TapRating and SwipeRating.
  * This documentation is for Tap Rating version. */
 export const AirbnbRating: RneFunctionComponent<TapRatingProps> = (props) => {

--- a/packages/base/src/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/base/src/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`Button Component clear should display disabled clear button 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -301,7 +301,7 @@ exports[`Button Component lg should display disabled lg button 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -572,7 +572,7 @@ exports[`Button Component md should display disabled md button 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -843,7 +843,7 @@ exports[`Button Component outline should display disabled outline button 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -1114,7 +1114,7 @@ exports[`Button Component sm should display disabled sm button 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -1385,7 +1385,7 @@ exports[`Button Component solid should display disabled solid button 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}

--- a/packages/base/src/Rating/Rating.tsx
+++ b/packages/base/src/Rating/Rating.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import {
   Rating as SwipeRating,
   SwipeRatingProps as RatingProps,
-} from 'react-native-ratings';
+} from '@rn-vui/ratings';
 import { RneFunctionComponent } from '../helpers';
 
-export interface SwipeRatingProps extends RatingProps {}
+export interface SwipeRatingProps extends RatingProps { }
 
 /** Ratings are used to collect measurable feedback from users.
  * Use Rating over an Input where imagery can increase user interaction.
- * This component is imported from [react-native-ratings](https://github.com/Monte9/react-native-ratings).
+ * This component is imported from [@rn-vui/ratings](https://github.com/deepktp/react-native-vikalp-ratings).
  * There are two tyoes of rating - TapRating and SwipeRating.
  * This documentation is for Swipe Rating version. */
 export const Rating: RneFunctionComponent<SwipeRatingProps> = (props) => {

--- a/packages/base/src/Rating/Rating.tsx
+++ b/packages/base/src/Rating/Rating.tsx
@@ -5,7 +5,7 @@ import {
 } from '@rn-vui/ratings';
 import { RneFunctionComponent } from '../helpers';
 
-export interface SwipeRatingProps extends RatingProps { }
+export interface SwipeRatingProps extends RatingProps {}
 
 /** Ratings are used to collect measurable feedback from users.
  * Use Rating over an Input where imagery can increase user interaction.

--- a/packages/base/src/Tab/Tab.tsx
+++ b/packages/base/src/Tab/Tab.tsx
@@ -29,7 +29,7 @@ export interface TabProps extends ViewProps, ParentProps {
   variant?: 'primary' | 'default';
 
   /** active index */
-  activeIndex?: number;
+  value?: number;
 
   /** Animation type */
   animationType?: 'timing' | 'spring';
@@ -89,7 +89,7 @@ export const TabBase: RneFunctionComponent<TabProps> = ({
   theme = defaultTheme,
   children,
   scrollable = false,
-  onChange = () => {},
+  onChange = () => { },
   indicatorStyle,
   disableIndicator,
   variant = 'primary',
@@ -99,7 +99,7 @@ export const TabBase: RneFunctionComponent<TabProps> = ({
   buttonStyle,
   titleStyle,
   containerStyle,
-  activeIndex = 0,
+  value: activeIndex = 0,
   animationType = 'spring',
   animationConfig = {},
   ...rest
@@ -111,7 +111,7 @@ export const TabBase: RneFunctionComponent<TabProps> = ({
   const setIndicatorRerenderKey = React.useState<number>(0)[1]; //to force re-render the indicator
 
   const animate = React.useCallback(
-    (toValue: number, onDone: (_: number) => void = () => {}) => {
+    (toValue: number, onDone: (_: number) => void = () => { }) => {
       currentIndex.current = toValue;
       onIndexChangeRef.current?.(toValue);
       //currently we are ignoring the animationConfig types but we need to fix this

--- a/packages/base/src/Tab/Tab.tsx
+++ b/packages/base/src/Tab/Tab.tsx
@@ -89,7 +89,7 @@ export const TabBase: RneFunctionComponent<TabProps> = ({
   theme = defaultTheme,
   children,
   scrollable = false,
-  onChange = () => { },
+  onChange = () => {},
   indicatorStyle,
   disableIndicator,
   variant = 'primary',
@@ -111,7 +111,7 @@ export const TabBase: RneFunctionComponent<TabProps> = ({
   const setIndicatorRerenderKey = React.useState<number>(0)[1]; //to force re-render the indicator
 
   const animate = React.useCallback(
-    (toValue: number, onDone: (_: number) => void = () => { }) => {
+    (toValue: number, onDone: (_: number) => void = () => {}) => {
       currentIndex.current = toValue;
       onIndexChangeRef.current?.(toValue);
       //currently we are ignoring the animationConfig types but we need to fix this

--- a/website/docs/components/AirbnbRating.mdx
+++ b/website/docs/components/AirbnbRating.mdx
@@ -15,7 +15,7 @@ import Play from "@site/playground/AirbnbRating/airbnbrating.playground";
 
 Ratings are used to collect measurable feedback from users.
 Use Rating over an Input where imagery can increase user interaction.
-This component is imported from [react-native-ratings](https://github.com/Monte9/react-native-ratings).
+This component is imported from [@rn-vui/ratings](https://github.com/deepktp/react-native-vikalp-ratings).
 There are two types of rating - TapRating and SwipeRating.
 This documentation is for Tap Rating version.
 
@@ -47,21 +47,23 @@ This documentation is for Tap Rating version.
 
 <div class='table-responsive'>
 
-| Name                   | Type                  | Default | Description                                                                                                                                                                      |
-| ---------------------- | --------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `count`                | number                |         | Total number of ratings to displayDefault is 5                                                                                                                                   |
-| `defaultRating`        | number                |         | Initial value for the ratingDefault is 3                                                                                                                                         |
-| `isDisabled`           | boolean               |         | Whether the rating can be modiefied by the userDefault is false                                                                                                                  |
-| `onFinishRating`       | (number: any) => void |         | Callback method when the user finishes rating. Gives you the final rating value as a whole number                                                                                |
-| `ratingContainerStyle` | View Style            |         | Style for rating containerDefault is none                                                                                                                                        |
-| `reviewColor`          | string                |         | Color value for review.Default is #f1c40f                                                                                                                                        |
-| `reviewSize`           | number                |         | Size value for review.Default is 40                                                                                                                                              |
-| `reviews`              | string[]              |         | Labels to show when each value is tappede.g. If the first star is tapped, then value in index 0 will be used as the labelDefault is ['Terrible', 'Bad', 'Okay', 'Good', 'Great'] |
-| `selectedColor`        | string                |         | Color value for filled stars.Default is #004666                                                                                                                                  |
-| `showRating`           | boolean               |         | Determines if to show the reviews above the ratingDefault is true                                                                                                                |
-| `size`                 | number                |         | Size of rating imageDefault is 40                                                                                                                                                |
-| `starContainerStyle`   | View Style            |         | Style for star containerDefault is none                                                                                                                                          |
-| `starImage`            | string                |         | Pass in a custom base image source                                                                                                                                               |
+| Name                   | Type                    | Default                                        | Description                                                                                                                 |
+| ---------------------- | ----------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `count`                | number                  | `5`                                            | Total number of ratings to display.                                                                                         |
+| `defaultRating`        | number                  | `3`                                            | Initial value for the rating                                                                                                |
+| `isDisabled`           | boolean                 | `false`                                        | Whether the rating can be modified by the user                                                                              |
+| `onFinishRating`       | (value: number) => void |                                                | Callback method when the user finishes rating. Gives you the final rating value as a whole number                           |
+| `ratingContainerStyle` | View Style              | `undefined`                                    | Style for rating container                                                                                                  |
+| `reviewColor`          | string                  | `#f1c40f`                                      | Color value for review.                                                                                                     |
+| `reviewSize`           | number                  | `40`                                           | Size value for review.                                                                                                      |
+| `reviews`              | string[]                | `['Terrible', 'Bad', 'Okay', 'Good', 'Great']` | Labels to show when each value is tapped.e.g. If the first star is tapped, then value in index 0 will be used as the label. |
+| `selectedColor`        | string                  | `#004666`                                      | Color value for filled stars.                                                                                               |
+| `showRating`           | boolean                 | `true`                                         | Determines if to show the reviews above the rating.                                                                         |
+| `size`                 | number                  | `40`                                           | Size of rating image                                                                                                        |
+| `starContainerStyle`   | View Style              | `undefined`                                    | Style for star container                                                                                                    |
+| `starImage`            | string                  |                                                | Pass in a custom base image source                                                                                          |
+| `starStyle`            | ImageStyle              |                                                | Style for star                                                                                                              |
+| `unSelectedColor`      | string                  | `#BDC3C7`                                      | Color value for not filled stars.                                                                                           |
 
 </div>
 

--- a/website/docs/components/Rating.mdx
+++ b/website/docs/components/Rating.mdx
@@ -15,7 +15,7 @@ import Play from "@site/playground/Rating/rating.playground";
 
 Ratings are used to collect measurable feedback from users.
 Use Rating over an Input where imagery can increase user interaction.
-This component is imported from [react-native-ratings](https://github.com/Monte9/react-native-ratings).
+This component is imported from [@rn-vui/ratings](https://github.com/deepktp/react-native-vikalp-ratings).
 There are two tyoes of rating - TapRating and SwipeRating.
 This documentation is for Swipe Rating version.
 
@@ -47,27 +47,27 @@ This documentation is for Swipe Rating version.
 
 <div class='table-responsive'>
 
-| Name                    | Type                  | Default | Description                                                                                                                |
-| ----------------------- | --------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `fractions`             | any                   |         | The number of decimal places for the rating value; must be between 0 and 20                                                |
-| `imageSize`             | number                |         | The size of each rating imageDefault is 50                                                                                 |
-| `jumpValue`             | number                |         | The number to jump per swipeDefault is 0 (not to jump)                                                                     |
-| `minValue`              | number                |         | The minimum value the user can selectDefault is 0                                                                          |
-| `onFinishRating`        | Function              |         | Callback method when the user finishes rating. Gives you the final rating value as a whole number                          |
-| `onStartRating`         | Function              |         | Callback method when the user starts rating.                                                                               |
-| `onSwipeRating`         | (number: any) => void |         | Callback method when the user is swiping.                                                                                  |
-| `ratingBackgroundColor` | string                |         | Pass in a custom background-fill-color for the rating icon; use this along with type='custom' prop aboveDefault is 'white' |
-| `ratingColor`           | string                |         | Pass in a custom fill-color for the rating icon; use this along with type='custom' prop aboveDefault is '#f1c40f'          |
-| `ratingCount`           | number                |         | Number of rating images to displayDefault is 5                                                                             |
-| `ratingImage`           | ReactNode             |         | Pass in a custom image source; use this along with type='custom' prop above                                                |
-| `ratingTextColor`       | string                |         | Color used for the text labels                                                                                             |
-| `readonly`              | boolean               |         | Whether the rating can be modiefied by the userDefault is false                                                            |
-| `showRating`            | boolean               |         | Displays the Built-in Rating UI to show the rating value in real-timeDefault is false                                      |
-| `showReadOnlyText`      | boolean               |         | Whether the text is read onlyDefault is false                                                                              |
-| `startingValue`         | number                |         | The initial rating to renderDefault is ratingCount/2                                                                       |
-| `style`                 | View Style            |         | Exposes style prop to add additonal styling to the container view                                                          |
-| `tintColor`             | string                |         | Color used for the background                                                                                              |
-| `type`                  | string                |         | Graphic used for represent a ratingDefault is 'star'                                                                       |
+| Name                    | Type                                                | Default           | Description                                                                                              |
+| ----------------------- | --------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------- |
+| `fractions`             | any                                                 | `0`               | The number of decimal places for the rating value; must be between 0 and 20                              |
+| `imageSize`             | number                                              | `50`              | The size of each rating image                                                                            |
+| `jumpValue`             | number                                              | `0 (not to jump)` | The number to jump per swipe                                                                             |
+| `minValue`              | number                                              | `0`               | The minimum value the user can select                                                                    |
+| `onFinishRating`        | Function                                            |                   | Callback method when the user finishes rating. Gives you the final rating value as a whole number        |
+| `onStartRating`         | Function                                            |                   | Callback method when the user starts rating.                                                             |
+| `onSwipeRating`         | (value: number) => void                             |                   | Callback method when the user is swiping.                                                                |
+| `ratingBackgroundColor` | string                                              | `'white'`         | Pass in a custom background-fill-color for the rating icon; use this along with type='custom' prop above |
+| `ratingColor`           | string                                              | `'#f1c40f'`       | Pass in a custom fill-color for the rating icon; use this along with type='custom' prop above            |
+| `ratingCount`           | number                                              | `5`               | Number of rating images to display                                                                       |
+| `ratingImage`           | ReactNode                                           |                   | Pass in a custom image source; use this along with type='custom' prop above                              |
+| `ratingTextColor`       | string                                              | `#f1c40f`         | Color used for the text labels                                                                           |
+| `readonly`              | boolean                                             | `false`           | Whether the rating can be modified by the user                                                           |
+| `showRating`            | boolean                                             | `false`           | Displays the Built-in Rating UI to show the rating value in real-time                                    |
+| `showReadOnlyText`      | boolean                                             | `false`           | Whether the text is read only                                                                            |
+| `startingValue`         | number                                              | `ratingCount/2`   | The initial rating to render                                                                             |
+| `style`                 | View Style                                          |                   | Exposes style prop to add additional styling to the container view                                       |
+| `tintColor`             | string                                              |                   | Color used for the background                                                                            |
+| `type`                  | `star` \| `heart` \| `rocket` \| `bell` \| `custom` | `star`            | Graphic used for represent a rating                                                                      |
 
 </div>
 

--- a/website/docs/components/Tab.mdx
+++ b/website/docs/components/Tab.mdx
@@ -88,21 +88,21 @@ Includes all [View](https://reactnative.dev/docs/view#props) props.
 
 <div class='table-responsive'>
 
-| Name               | Type                                                       | Default    | Description                              |
-| ------------------ | ---------------------------------------------------------- | ---------- | ---------------------------------------- |
-| `activeIndex`      | number                                                     | `0`        | active index                             |
-| `animationConfig`  | `TimingAnimationConfig` \| `SpringAnimationConfig(Object)` | `{}`       | Animation Config                         |
-| `animationType`    | `spring` \| `timing`                                       | `spring`   | Animation type                           |
-| `buttonStyle`      | `ViewStyle or (active: boolean) => ViewStyle`              | `none`     | Additional button style                  |
-| `containerStyle`   | ViewStyle or (active: boolean) => ViewStyle                | `none`     | Additional Styling for button container. |
-| `dense`            | boolean                                                    | `none`     | Dense Tab Item                           |
-| `disableIndicator` | boolean                                                    |            | Disable the indicator below.             |
-| `iconPosition`     | `left` \| `right` \| `top` \| `bottom`                     | `none`     |                                          |
-| `indicatorStyle`   | View Style                                                 |            | Additional styling for tab indicator.    |
-| `onChange`         | (value: number) => void                                    | `Function` | On Index Change Callback.                |
-| `scrollable`       | boolean                                                    | `false`    | Makes Tab Scrolling                      |
-| `titleStyle`       | TextStyle or (active: boolean) => TextStyle                | `none`     | Additional button title style            |
-| `variant`          | `primary` \| `default`                                     | `primary`  | Define the background Variant.           |
+| Name               | Type                                                       | Default     | Description                              |
+| ------------------ | ---------------------------------------------------------- | ----------- | ---------------------------------------- |
+| `animationConfig`  | `TimingAnimationConfig` \| `SpringAnimationConfig(Object)` | `{}`        | Animation Config                         |
+| `animationType`    | `spring` \| `timing`                                       | `spring`    | Animation type                           |
+| `buttonStyle`      | `ViewStyle or (active: boolean) => ViewStyle`              | `none`      | Additional button style                  |
+| `containerStyle`   | ViewStyle or (active: boolean) => ViewStyle                | `none`      | Additional Styling for button container. |
+| `dense`            | boolean                                                    | `none`      | Dense Tab Item                           |
+| `disableIndicator` | boolean                                                    |             | Disable the indicator below.             |
+| `iconPosition`     | `left` \| `right` \| `top` \| `bottom`                     | `none`      |                                          |
+| `indicatorStyle`   | View Style                                                 |             | Additional styling for tab indicator.    |
+| `onChange`         | (value: number) => void                                    | `() => { }` | On Index Change Callback.                |
+| `scrollable`       | boolean                                                    | `false`     | Makes Tab Scrolling                      |
+| `titleStyle`       | TextStyle or (active: boolean) => TextStyle                | `none`      | Additional button title style            |
+| `value`            | number                                                     |             | active index                             |
+| `variant`          | `primary` \| `default`                                     | `primary`   | Define the background Variant.           |
 
 </div>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3988,6 +3988,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rn-vui/base@workspace:packages/base"
   dependencies:
+    "@rn-vui/ratings": "npm:^0.4.1"
     "@types/color": "npm:^3.0.3"
     "@types/hoist-non-react-statics": "npm:^3.3.1"
     "@types/react-native-vector-icons": "npm:^6.4.10"
@@ -3995,7 +3996,6 @@ __metadata:
     deepmerge: "npm:^4.2.2"
     hoist-non-react-statics: "npm:^3.3.2"
     metro-react-native-babel-preset: "npm:^0.70.2"
-    react-native-ratings: "npm:^8.1.0"
     react-native-safe-area-context: "npm:4.14.0"
     react-native-size-matters: "npm:^0.4.0"
     react-native-vector-icons: "npm:^10.1.0"
@@ -4021,6 +4021,16 @@ __metadata:
     typescript: "npm:^4.6.4"
   languageName: unknown
   linkType: soft
+
+"@rn-vui/ratings@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@rn-vui/ratings@npm:0.4.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/af86d516409a8e444a45f2f6a545d5cbe5865ed9c1ab16df280b372c265ec259206f253844e2ee85dfe05d6527f5f919e6aaa50e9c148b407acf4142a176cbc7
+  languageName: node
+  linkType: hard
 
 "@rn-vui/themed@workspace:packages/themed":
   version: 0.0.0-use.local
@@ -15564,18 +15574,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/64ab125c539ca8c275f5d305f5e11d366e6098d9e24e3cab25cbfd46a8d618fc3925ea86219972ccc63364e578384bb0120a72562312e596894a04ee0518a363
-  languageName: node
-  linkType: hard
-
-"react-native-ratings@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "react-native-ratings@npm:8.1.0"
-  dependencies:
-    lodash: "npm:^4.17.15"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 10/618ad478f41b6d913a76342a5325510b57b2d6bc52994f50ea9070eb4d1d1191fecca01b7e4120b9f9d6e0bd84040584ff7cf43d3bb4142c5ea49dd275308ac8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix: issue #22 tab component now use `value` prop instead of `activeIndex` to remove breaking change to migrate to vikalp elements.

Fix issue #25 airbnb ratings not showing in react native 79+ due to removed support for default props

> Changed Tabs prop `activeIndex` to `value`
> changed dependency library `react-native-ratings` to `@rn-vui/ratings` as it was not maintained
> `@rn-vui/ratings` fixes issue of ratings images not showing in react native 79+ 