### PR TITLE
fix: pass testId from SpeedDialAction to FAB

### DIFF
--- a/packages/base/src/SpeedDial/SpeedDial.Action.tsx
+++ b/packages/base/src/SpeedDial/SpeedDial.Action.tsx
@@ -16,6 +16,7 @@ export const SpeedDialAction: RneFunctionComponent<SpeedDialActionProps> = ({
   placement,
   labelPressable,
   onPress,
+  testID,
   ...actionProps
 }) => {
   return (
@@ -34,6 +35,7 @@ export const SpeedDialAction: RneFunctionComponent<SpeedDialActionProps> = ({
         onPress={onPress}
         size="small"
         style={[actionProps.style]}
+        testID={testID}
       />
     </Pressable>
   );

--- a/packages/base/src/SpeedDial/__tests__/SpeedDial.Action.test.tsx
+++ b/packages/base/src/SpeedDial/__tests__/SpeedDial.Action.test.tsx
@@ -18,4 +18,15 @@ describe('Speed Dial Action', () => {
     fireEvent(title, 'press');
     expect(onPress).toHaveBeenCalled();
   });
+
+  it('should pass testID to FAB component', () => {
+    const { getByTestId } = renderWithWrapper(
+      <SpeedDial.Action
+        icon={{ name: 'delete', color: '#fff' }}
+        title="Delete"
+        testID="speed-dial-action"
+      />
+    );
+    expect(getByTestId('speed-dial-action')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Motivation

SpeedDial Actions aren't properly testable atm. This should fix this by passing testIds down to the FAB/

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Jest Unit Test
- [ ] Checked with `example` app

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
