### PR TITLE
[Docs] Overlay component remove web specific note about Modal component

### DIFF
--- a/website/docs/component_usage/Overlay.mdx
+++ b/website/docs/component_usage/Overlay.mdx
@@ -1,22 +1,6 @@
 <!-- To show the guide to configure the Overlay Component to a project.
 This is not added as description in comments of the component so is added here. -->
 
----
-
-> **Web-platform specific note**:
->
-> You **must** pass a valid React Native [`Modal`](https://reactnative.dev/docs/modal) component implementation
-> into [`ModalComponent`](#modalcomponent) prop because `Modal` component is not implemented yet in `react-native-web`
-
-```jsx
-...
-import Modal from 'modal-react-native-web';
-
-...
-
-<Overlay ModalComponent={Modal} ... />
-...
-```
 
 ```SnackPlayer name=RNE Overlay
 import React, { useState } from 'react';

--- a/website/versioned_docs/version-6.0.0-rc.0/component_usage/Overlay.mdx
+++ b/website/versioned_docs/version-6.0.0-rc.0/component_usage/Overlay.mdx
@@ -1,22 +1,6 @@
 <!-- To show the guide to configure the Overlay Component to a project.
 This is not added as description in comments of the component so is added here. -->
 
----
-
-> **Web-platform specific note**:
->
-> You **must** pass a valid React Native [`Modal`](https://reactnative.dev/docs/modal) component implementation
-> into [`ModalComponent`](#modalcomponent) prop because `Modal` component is not implemented yet in `react-native-web`
-
-```jsx
-...
-import Modal from 'modal-react-native-web';
-
-...
-
-<Overlay ModalComponent={Modal} ... />
-...
-```
 
 ```SnackPlayer name=RNE Overlay
 import React, { useState } from 'react';


### PR DESCRIPTION
## Motivation

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The modal component is supported natively in react-native-web (https://github.com/necolas/react-native-web/releases/tag/0.14.0 for some time now already), so this PR removes the web specific note that says you need a 3rd party modal library for the modal component.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Jest Unit Test
- [ ] Checked with `example` app

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation using `yarn docs-build-api`
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
It's just a documentation update, so no code testing needed etc.

<!-- Add any other context or screenshots about the feature request here. -->
| Before | After |
| ----------- | ----------- |
|<img width="1186" height="1088" alt="image" src="https://github.com/user-attachments/assets/10e5c2a2-9a91-44c0-b54e-d0537658bb7b" />|<img width="1111" height="1069" alt="image" src="https://github.com/user-attachments/assets/1b1eb3e6-129a-41c9-b390-111a462486de" />|